### PR TITLE
Support running in null-safety mode

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,9 @@
 name: node_preamble
 author: Michael Bullington <mikebullingtn@gmail.com>
 homepage: https://github.com/mbullington/node_preamble.dart
-version: 1.4.12
+version: 1.4.13-nullsafety
 description: Better node.js preamble for dart2js, use it in your build system.
 
 environment:
-  sdk: '>=1.24.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
-dev_dependencies:
-  http: '^0.11.0'


### PR DESCRIPTION
Setting the minimum SDK to 2.12 allows packages that depend on this to migrate to null-safety.

The http package is no longer used and it hasn't been migrated yet, so I also removed the dependency.

This should be released as a pre-release version now and then as a stable version once the stable version of Dart 2.12 is released.