### PR TITLE
Bump version, oops!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.4.14
+
+* Fixes detection on Electron with `nodeIntegration` disabled
+
+# 1.4.13-nullsafety
+
+* Support running in null-safety mode
+
 # 1.4.10-1.4.12
 
 Hotfix again for Electron support, quite embarassing at this point. Verified using the awesome Electron Fiddle tool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
-# 1.4.14
+# 1.4.13
 
 * Fixes detection on Electron with `nodeIntegration` disabled
-
-# 1.4.13-nullsafety
-
-* Support running in null-safety mode
 
 # 1.4.10-1.4.12
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: node_preamble
 author: Michael Bullington <mikebullingtn@gmail.com>
 homepage: https://github.com/mbullington/node_preamble.dart
-version: 1.4.13-nullsafety
+version: 1.4.14-nullsafety
 description: Better node.js preamble for dart2js, use it in your build system.
 
 environment:


### PR DESCRIPTION
Forgot to bump the version in my last PR(!)
This does that and adds it to the changelog as well as the previous nullsafety version.