### PR TITLE
Detect the Deno environment

### DIFF
--- a/lib/preamble.js
+++ b/lib/preamble.js
@@ -36,9 +36,9 @@ if (typeof Buffer !== "undefined") {
 }
 
 // if we're running in a browser, Dart supports most of this out of box
-// make sure we only run these in Node.js environment
+// make sure we only run these in Node.js or Deno environments
 
-var dartNodeIsActuallyNode = !dartNodePreambleSelf.window
+var dartNodeIsActuallyNode = !dartNodePreambleSelf.window || dartNodePreambleSelf.window.Deno;
 
 try {
   // Check if we're in a Web Worker instead.


### PR DESCRIPTION
Coming from https://github.com/sass/dart-sass/issues/1834

The `window` object exists in Deno, so the test incorrectly assume that the code is running in a browser. This change detects Deno in order use the same code to Node and Deno.