### PR TITLE
Explicitly support Dart 3 and follow modern standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.0-wip
+
+* Require Dart 2.19 or later and explicitly support Dart 3.
+* No longer explicitly name library as `node_preamble`.
+
 # 2.0.2
 
 * Don't crash when running in browser environments.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also get the preamble via Dart, like in the following example.
 ```
 import "package:node_preamble/preamble.dart" as preamble;
 
-main() {
+void main() {
   print(preamble.getPreamble());
 }
 ```

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,5 +1,5 @@
 import "package:node_preamble/preamble.dart" as preamble;
 
-main() {
+void main() {
   print(preamble.getPreamble());
 }

--- a/lib/preamble.dart
+++ b/lib/preamble.dart
@@ -1,8 +1,7 @@
-library node_preamble;
+const _minified =
+    r"""var dartNodeIsActuallyNode="undefined"!=typeof process&&(process.versions||{}).hasOwnProperty("node"),self=dartNodeIsActuallyNode?Object.create(globalThis):globalThis;if(self.scheduleImmediate="undefined"!=typeof setImmediate?function(e){setImmediate(e)}:function(e){setTimeout(e,0)},"undefined"!=typeof require)self.require=require;if("undefined"!=typeof exports)self.exports=exports;if("undefined"!=typeof process)self.process=process;if("undefined"!=typeof __dirname)self.__dirname=__dirname;if("undefined"!=typeof __filename)self.__filename=__filename;if("undefined"!=typeof Buffer)self.Buffer=Buffer;if(dartNodeIsActuallyNode){var url=("undefined"!=typeof __webpack_require__?__non_webpack_require__:require)("url");Object.defineProperty(self,"location",{value:{get href(){if(url.pathToFileURL)return url.pathToFileURL(process.cwd()).href+"/";else return"file://"+function(){var e=process.cwd();if("win32"!=process.platform)return e;else return"/"+e.replace(/\\/g,"/")}()+"/"}}}),function(){function e(){try{throw new Error}catch(n){var e=n.stack,r=new RegExp("^ *at [^(]*\\((.*):[0-9]*:[0-9]*\\)$","mg"),f=null;do{var t=r.exec(e);if(null!=t)f=t}while(null!=t);return f[1]}}var r=null;Object.defineProperty(self,"document",{value:{get currentScript(){if(null==r)r={src:e()};return r}}})}(),self.dartDeferredLibraryLoader=function(e,r,f){try{load(e),r()}catch(e){f(e)}}}""";
 
-final _minified = r"""var dartNodeIsActuallyNode="undefined"!=typeof process&&(process.versions||{}).hasOwnProperty("node"),self=dartNodeIsActuallyNode?Object.create(globalThis):globalThis;if(self.scheduleImmediate="undefined"!=typeof setImmediate?function(e){setImmediate(e)}:function(e){setTimeout(e,0)},"undefined"!=typeof require)self.require=require;if("undefined"!=typeof exports)self.exports=exports;if("undefined"!=typeof process)self.process=process;if("undefined"!=typeof __dirname)self.__dirname=__dirname;if("undefined"!=typeof __filename)self.__filename=__filename;if("undefined"!=typeof Buffer)self.Buffer=Buffer;if(dartNodeIsActuallyNode){var url=("undefined"!=typeof __webpack_require__?__non_webpack_require__:require)("url");Object.defineProperty(self,"location",{value:{get href(){if(url.pathToFileURL)return url.pathToFileURL(process.cwd()).href+"/";else return"file://"+function(){var e=process.cwd();if("win32"!=process.platform)return e;else return"/"+e.replace(/\\/g,"/")}()+"/"}}}),function(){function e(){try{throw new Error}catch(n){var e=n.stack,r=new RegExp("^ *at [^(]*\\((.*):[0-9]*:[0-9]*\\)$","mg"),f=null;do{var t=r.exec(e);if(null!=t)f=t}while(null!=t);return f[1]}}var r=null;Object.defineProperty(self,"document",{value:{get currentScript(){if(null==r)r={src:e()};return r}}})}(),self.dartDeferredLibraryLoader=function(e,r,f){try{load(e),r()}catch(e){f(e)}}}""";
-
-final _normal = r"""
+const _normal = r"""
 var dartNodeIsActuallyNode = typeof process !== "undefined" && (process.versions || {}).hasOwnProperty('node');
 
 // make sure to keep this as 'var'
@@ -122,6 +121,9 @@ if (dartNodeIsActuallyNode) {
 ///
 /// If [minified] is true, returns the minified version rather than the
 /// human-readable version.
-String getPreamble({bool minified: false, List<String> additionalGlobals: const []}) =>
+String getPreamble({
+  bool minified = false,
+  List<String> additionalGlobals = const [],
+}) =>
     (minified ? _minified : _normal) +
     (additionalGlobals.map((global) => "self.$global=$global;").join());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
 name: node_preamble
-author: Michael Bullington <mikebullingtn@gmail.com>
 homepage: https://github.com/mbullington/node_preamble.dart
-version: 2.0.2
+version: 2.1.0-wip
 description: Better node.js preamble for dart2js, use it in your build system.
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'

--- a/tool/minify.js
+++ b/tool/minify.js
@@ -25,18 +25,20 @@ if (error) {
 
 fs.writeFileSync(MIN_PATH, minified);
 
-fs.writeFileSync(DART_PATH, `library node_preamble;
+fs.writeFileSync(DART_PATH, `const _minified =
+    r\"""${minified}\""";
 
-final _minified = r\"""${minified}\""";
-
-final _normal = r\"""
+const _normal = r\"""
 ${preamble}\""";
 
 /// Returns the text of the preamble.
 ///
 /// If [minified] is true, returns the minified version rather than the
 /// human-readable version.
-String getPreamble({bool minified: false, List<String> additionalGlobals: const []}) =>
+String getPreamble({
+  bool minified = false,
+  List<String> additionalGlobals = const [],
+}) =>
     (minified ? _minified : _normal) +
     (additionalGlobals.map((global) => "self.\$global=\$global;").join());
 `);


### PR DESCRIPTION
- Expand SDK constraint to explicitly indicate support for Dart 3
- Replace colons for specifying optional named parameter default values with equal signs. Support for the using colons has been deprecated for a while and is [no longer supported](https://dart.dev/tools/diagnostic-messages#obsolete_colon_for_default_value) with a language version >= 3.
- Remove explicitly named library declaration which isn't used for anything.
- Adjust code generator to be compliant with `dart format`.
- Remove the `author` field in the pubspec which is [deprecated and no longer used](https://github.com/dart-lang/pub/issues/2234).