### PR TITLE
Cleanup pubspec for latest guidelines

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,9 @@
 name: node_preamble
-author: Michael Bullington <mikebullingtn@gmail.com>
-homepage: https://github.com/mbullington/node_preamble.dart
+repository: https://github.com/mbullington/node_preamble.dart
 version: 2.0.2
 description: Better node.js preamble for dart2js, use it in your build system.
+topics: 
+  - node
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
- Removes `author` now that [pub doesn't use it](https://github.com/dart-lang/site-www/issues/2029)
- Replaces `homepage` with [`repository`](https://dart.dev/tools/pub/pubspec#repository)
- Add a [topic](https://dart.dev/tools/pub/pubspec#topics)